### PR TITLE
Add path config in Makefile for use in different environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+LO_PATH=/opt/libreofficedev6.4
+LO_BIN=$(LO_PATH)/program
+LO_UNOPKG=$(LO_BIN)/unopkg
+
 all:	clean zip install
 
+
 clean:
-	unopkg remove ThemeChanger.oxt
+	$(LO_UNOPKG) remove ThemeChanger.oxt
 	rm ThemeChanger.oxt
 
 zip:
@@ -15,4 +20,4 @@ zip:
 		description/*
 
 install:
-	unopkg add ThemeChanger.oxt
+	$(LO_UNOPKG) add ThemeChanger.oxt


### PR DESCRIPTION
The executive unopkg may reside in different path in different system/machines.  So use a variable to setup the path for now.  Later maybe need to auto-detect the path (but it can be done in the last)