### PR TITLE
registrymodifications hack for custom icon theme and custom toolbar layout

### DIFF
--- a/description.xml
+++ b/description.xml
@@ -21,7 +21,7 @@ Tip: When edited open file in browser to check for errors.
     -->
     <identifier value="id.libreoffice.themechanger"/>
 
-    <version value="0.3.5"/>
+    <version value="0.3.9-alpha"/>
 
     <platform value="all"/>
 

--- a/description/title.txt
+++ b/description/title.txt
@@ -1,1 +1,1 @@
-LibreOfficeThemeChanger v 0.3.5
+LibreOfficeThemeChanger v 0.3.9-alpha

--- a/pythonpath/ThemeChanger/CreateDialog.py
+++ b/pythonpath/ThemeChanger/CreateDialog.py
@@ -53,6 +53,7 @@ class CreateDialog(CreateDialog_UI):
                 Et.SubElement(root, "author").text = data["author"]
                 Et.SubElement(root, "author_url").text = "https://mywebsite.com"
                 Et.SubElement(root, "description").text = "this is my libreoffice theme description"
+                Et.SubElement(root, "icon_theme").text = "Srikandi"
                 personas = Et.SubElement(root, "assets", {"id": "personas"})
                 Et.SubElement(personas, "persona_list").text = "personas/personas_list.txt"
                 Et.SubElement(personas, "footer_img").text = "personas/{}/footer.png".format(data["name"].title().replace(" ",""))
@@ -66,7 +67,8 @@ class CreateDialog(CreateDialog_UI):
                 Et.SubElement(screenshots, "img", {"id": "screenshot-2"}).text = "screenshots/screenshot-2.png"
                 source_link = Et.SubElement(root, "source_link")
                 Et.SubElement(source_link, "link", {"id": "1", "src": "https://source-link-1"}).text = "About {}".format(data["name"])
-                Et.SubElement(source_link, "link", {"id": "2", "src": "https://source-link-2"}).text = "License"
+                Et.SubElement(source_link, "link", {"id": "2", "src": "https://source-link-2"}).text = "(2/2) Remove this line if not used"
+                Et.SubElement(root, "custom_xcu").text = "Please refer to LOTC Documentation to use custom registrymodifications.xcu. Remove this line if not used"
                 # write to file
                 tree = Et.ElementTree(root)
                 self.indent(root)

--- a/pythonpath/ThemeChanger/Helper.py
+++ b/pythonpath/ThemeChanger/Helper.py
@@ -231,6 +231,24 @@ def parse_manifest(manifest_dir):
         version = root.find("version").text
         author = root.find("author").text
         author_link = root.find("author_url").text
+        if root.find("icon_theme") != None:
+            icon_theme = root.find("icon_theme").text
+        else:
+            icon_theme = "auto"
+        # parsing custom_xcu
+        if root.find("custom_xcu") != None:
+            # get first index of XCU parent (oor:items)
+            xcu_node = root.find("custom_xcu")[0]
+            custom_xcu = []
+            for item in xcu_node:
+                current_item = {"path": item.attrib.get('{http://openoffice.org/2001/registry}path')}
+                property_name = item.find('prop').attrib.get('{http://openoffice.org/2001/registry}name')
+                current_item["property_name"] = property_name
+                property_value = item.find('prop').find('value').text
+                current_item["property_value"] = property_value
+                custom_xcu.append(current_item)
+        else:
+            custom_xcu = []
         if sys.platform.startswith("win"):
             screenshots = ["file:///{}\\{}".format(replace_separator(manifest_dir,"/","\\"), replace_separator(ss.text,"/","\\")) for ss in root.findall("assets/img")]
         else:
@@ -244,13 +262,13 @@ def parse_manifest(manifest_dir):
             "name": theme_name,
             "screenshots": screenshots,
             "version": version,
-            "source_link": source_link
+            "source_link": source_link,
+            "icon_theme": icon_theme,
+            "custom_xcu" : custom_xcu
         }
         # print(data)
         return data
-    except Exception as e:
-        print(e)
-        traceback.print_exc()
+    except FileNotFoundError:
         return None
 
 def get_user_dir(ctx):
@@ -281,4 +299,3 @@ def get_configvalue(ctx, nodepath, prop):
 
 def replace_separator(text, what="\\", withs="/"):
     return text.replace(what,withs)
-    

--- a/pythonpath/ThemeChanger/MainDialog.py
+++ b/pythonpath/ThemeChanger/MainDialog.py
@@ -207,7 +207,9 @@ class MainDialog(MainDialog_UI):
                     "author": "LibreOffice",
                     "description": "LibreOffice default theme",
                     "name": theme_name,
-                    "screenshots": ["file://{}/program/intro.png".format(theme_dir)]
+                    "icon_theme": "auto",
+                    "screenshots": ["file://{}/program/intro.png".format(theme_dir)],
+                    "custom_xcu" : []
                 }
                 if sys.platform.startswith("win"):
                     theme_data["screenshots"] = ["file:///{}/program/intro.png".format(Helper.replace_separator(theme_dir))]


### PR DESCRIPTION
example data in `manifest.xml` for custom registrymodifications.xcu 
(place these lines inside `<custom_xcu>`):
```
<oor:items xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <item oor:path="/org.openoffice.Office.UI.WriterWindowState/UIElements/States/org.openoffice.Office.UI.WindowState:WindowStateType['private:resource/toolbar/standardbar']"><prop oor:name="Locked" oor:op="fuse"><value>true</value></prop></item>
  <item oor:path="/org.openoffice.Office.UI.WriterWindowState/UIElements/States/org.openoffice.Office.UI.WindowState:WindowStateType['private:resource/toolbar/textobjectbar']"><prop oor:name="DockPos" oor:op="fuse"><value>0,21</value></prop></item>
  <item oor:path="/org.openoffice.Office.UI.WriterWindowState/UIElements/States/org.openoffice.Office.UI.WindowState:WindowStateType['private:resource/toolbar/textobjectbar']"><prop oor:name="DockingArea" oor:op="fuse"><value>2</value></prop></item>
  <item oor:path="/org.openoffice.Office.UI.WriterWindowState/UIElements/States/org.openoffice.Office.UI.WindowState:WindowStateType['private:resource/toolbar/textobjectbar']"><prop oor:name="Locked" oor:op="fuse"><value>true</value></prop></item>
  <item oor:path="/org.openoffice.Office.UI.WriterWindowState/UIElements/States/org.openoffice.Office.UI.WindowState:WindowStateType['private:resource/toolbar/textobjectbar']"><prop oor:name="Size" oor:op="fuse"><value>1196,39</value></prop></item>
</oor:items>
```